### PR TITLE
Support search result id for universal links

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -8,7 +8,7 @@
       },
       {
         "appID": "G4JB6X9K6T.denkeni.EbookTW",
-        "paths": ["/search", "/searches"]
+        "paths": ["/search", "/search/*", "/searches", "/searches/*"]
       }
     ]
   }


### PR DESCRIPTION
For urls like https://taiwan-ebook-lover.github.io/searches/8NmUwJavZE7ybMQIWDaM to work as universal links.