### PR TITLE
fix: Import gtag id from secrets in build process.

### DIFF
--- a/.github/workflows/eslint-check.yml
+++ b/.github/workflows/eslint-check.yml
@@ -1,11 +1,6 @@
 name: ESLint check
 
-on:
-  pull_request:
-    paths-ignore:
-      - '.github/**'
-      - '.husky/**'
-      - 'node_modules/**'
+on: pull_request
 
 jobs:
   main:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         run: yarn build
         env:
           VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+          VITE_GTAG_ID: ${{ secrets.VITE_GTAG_ID }}
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.7


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
遺漏了將環境變數從 Secrets 中拉進 Build 程序，補上

另外發現 `path-ignore` 會導致只更改根目錄的檔案時，會導致 check 無法被執行，
lint 一般也不會去檢查奇怪的東西，因此順手將 `path-ignore` 刪掉

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

如果現有的 `VITE_API_BASE_URL` 可以成功拉進來，照理說 `VITE_GTAG_ID` 要可以。
但也怕有意外，因為 `VITE_GTAG_ID` 使用情境比較特別是他被用來 inject 到 `index.html` 中，不太確定是否跟一般 `import.meta.env.VITE_API_BASE_URL` 是否有差。