### PR TITLE
fix: Styled components organization.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,11 @@
-import Box from '@components/Box';
-import { faCircleNotch } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import Routes from '@routes';
+import FullSizeLoading from '@components/FullSizeLoading';
 import { FunctionComponent, Suspense } from 'react';
 import { useThemeSwitcher } from 'react-css-theme-switcher';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { BrowserRouter } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
+import Routes from './routes';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -19,21 +17,6 @@ const queryClient = new QueryClient({
   },
 });
 
-const SuspenseLoading: FunctionComponent = () => {
-  return (
-    <Box
-      height="100vh"
-      display="flex"
-      flexDirection="column"
-      justifyContent="center"
-      alignItems="center"
-    >
-      <FontAwesomeIcon icon={faCircleNotch} className="fa-spin" style={{ fontSize: 24 }} />
-      <Box mt="1rem">Loading...</Box>
-    </Box>
-  );
-};
-
 const App: FunctionComponent = () => {
   const { status } = useThemeSwitcher();
 
@@ -43,7 +26,7 @@ const App: FunctionComponent = () => {
     <QueryClientProvider client={queryClient}>
       <RecoilRoot>
         <BrowserRouter>
-          <Suspense fallback={<SuspenseLoading />}>
+          <Suspense fallback={<FullSizeLoading />}>
             <Routes />
           </Suspense>
         </BrowserRouter>

--- a/src/components/FullSizeLoading/index.tsx
+++ b/src/components/FullSizeLoading/index.tsx
@@ -1,0 +1,21 @@
+import Box from '@components/Box';
+import { faCircleNotch } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { FunctionComponent } from 'react';
+
+const FullSizeLoading: FunctionComponent = () => {
+  return (
+    <Box
+      height="100%"
+      display="flex"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <FontAwesomeIcon icon={faCircleNotch} className="fa-spin" style={{ fontSize: 24 }} />
+      <Box mt="1rem">Loading...</Box>
+    </Box>
+  );
+};
+
+export default FullSizeLoading;

--- a/src/components/GetApp/index.tsx
+++ b/src/components/GetApp/index.tsx
@@ -1,10 +1,9 @@
 import appStoreBadge from '@assets/images/storeBadge/app-store-badge.svg';
 import googlePlayBadge from '@assets/images/storeBadge/play-store-badge.svg';
-import { breakpoints } from '@assets/themes/globalTheme';
 import Box from '@components/Box';
-import { Button, Modal } from 'antd';
+import { Modal } from 'antd';
 import { FunctionComponent, useState } from 'react';
-import styled from 'styled-components';
+import { GetAppButton, PlatformBadge } from './styles';
 
 export interface GetAppProps {
   textcolor?: 'grey' | 'white';
@@ -14,28 +13,6 @@ export enum PlatformType {
   ANDROID,
   IOS,
 }
-
-const StyledBadge = styled.img`
-  cursor: pointer;
-  max-height: 5rem;
-
-  & + & {
-    margin: 1.5rem 0 0 0;
-  }
-
-  @media (min-width: ${breakpoints.md}) {
-    max-height: 2.5rem;
-
-    & + & {
-      margin: 0 0 0 0.5rem;
-    }
-  }
-`;
-
-const StyledGetAppButton = styled(Button)<GetAppProps>`
-  color: ${({ textcolor }) =>
-    textcolor === 'grey' ? 'var(--gray-7)' : 'var(--gray-1)'} !important;
-`;
 
 const links: Record<PlatformType, string> = {
   [PlatformType.ANDROID]:
@@ -49,8 +26,8 @@ const openLink = (platform: PlatformType) => {
 
 const Badges = () => (
   <>
-    <StyledBadge src={appStoreBadge} alt="App Store" onClick={() => openLink(PlatformType.IOS)} />
-    <StyledBadge
+    <PlatformBadge src={appStoreBadge} alt="App Store" onClick={() => openLink(PlatformType.IOS)} />
+    <PlatformBadge
       src={googlePlayBadge}
       alt="Google Play Store"
       onClick={() => openLink(PlatformType.ANDROID)}
@@ -67,9 +44,9 @@ const GetApp: FunctionComponent<GetAppProps> = ({ textcolor = 'grey' }) => {
         <Badges />
       </Box>
       <Box display={['block', null, null, 'none']} height="2.5rem">
-        <StyledGetAppButton type="text" textcolor={textcolor} onClick={() => setModalOpen(true)}>
+        <GetAppButton type="text" textcolor={textcolor} onClick={() => setModalOpen(true)}>
           Get App
-        </StyledGetAppButton>
+        </GetAppButton>
       </Box>
       <Modal
         title="Get App"

--- a/src/components/GetApp/styles.ts
+++ b/src/components/GetApp/styles.ts
@@ -1,0 +1,26 @@
+import { breakpoints } from '@assets/themes/globalTheme';
+import { Button } from 'antd';
+import styled from 'styled-components';
+import { GetAppProps } from '.';
+
+export const PlatformBadge = styled.img`
+  cursor: pointer;
+  max-height: 5rem;
+
+  & + & {
+    margin: 1.5rem 0 0 0;
+  }
+
+  @media (min-width: ${breakpoints.md}) {
+    max-height: 2.5rem;
+
+    & + & {
+      margin: 0 0 0 0.5rem;
+    }
+  }
+`;
+
+export const GetAppButton = styled(Button)<GetAppProps>`
+  color: ${({ textcolor }) =>
+    textcolor === 'grey' ? 'var(--gray-7)' : 'var(--gray-1)'} !important;
+`;

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,44 +1,12 @@
 import ebookLogo from '@assets/images/logo/ebook-logo.svg';
-import { breakpoints } from '@assets/themes/globalTheme';
 import Box from '@components/Box';
 import FilterDrawer from '@components/FilterDrawer';
 import GetApp from '@components/GetApp';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button } from 'antd';
 import { FunctionComponent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
-
-const StyledNavbar = styled.header`
-  padding: 1rem;
-  display: flex;
-  background-color: var(--primary-color);
-  color: var(--gray-1);
-  z-index: 100;
-  box-shadow: 0px 0.25rem 0.25rem rgba(0, 0, 0, 0.3);
-`;
-
-const StyledLogo = styled.img`
-  height: 2.5rem;
-  margin: 0 0.5rem;
-  cursor: pointer;
-`;
-
-const StyledTitle = styled.span`
-  font-size: 1.5rem;
-  font-weight: 300;
-  line-height: 1.5;
-  display: none;
-
-  @media (min-width: ${breakpoints.md}) {
-    display: inline;
-  }
-`;
-
-const StyledSearchButton = styled(Button)`
-  color: var(--gray-1) !important;
-`;
+import { Logo, NavbarWrapper, SearchButton, Title } from './styles';
 
 export interface NavbarProps {
   onConfirm?: () => void;
@@ -55,7 +23,7 @@ const Navbar: FunctionComponent<NavbarProps> = ({ onConfirm }) => {
 
   return (
     <>
-      <StyledNavbar>
+      <NavbarWrapper>
         <Box
           flex="2"
           display="flex"
@@ -68,8 +36,8 @@ const Navbar: FunctionComponent<NavbarProps> = ({ onConfirm }) => {
             alignItems="center"
             justifyContent={['center', null, null, 'flex-start']}
           >
-            <StyledLogo src={ebookLogo} onClick={() => navigate('/')} />
-            <StyledTitle>台灣電子書搜尋</StyledTitle>
+            <Logo src={ebookLogo} onClick={() => navigate('/')} />
+            <Title>台灣電子書搜尋</Title>
           </Box>
           <Box
             flex="1"
@@ -77,15 +45,15 @@ const Navbar: FunctionComponent<NavbarProps> = ({ onConfirm }) => {
             alignItems="center"
             justifyContent="flex-start"
           >
-            <StyledSearchButton type="text" onClick={() => setDrawerVisible(true)}>
+            <SearchButton type="text" onClick={() => setDrawerVisible(true)}>
               <FontAwesomeIcon icon={faSearch} style={{ fontSize: '1.5rem' }} />
-            </StyledSearchButton>
+            </SearchButton>
           </Box>
         </Box>
         <Box flex="1" display="flex" justifyContent="flex-end">
           <GetApp textcolor="white" />
         </Box>
-      </StyledNavbar>
+      </NavbarWrapper>
       <FilterDrawer visible={drawerVisible} onConfirm={onFormConfirm} onClose={onFormConfirm} />
     </>
   );

--- a/src/components/Navbar/styles.ts
+++ b/src/components/Navbar/styles.ts
@@ -1,0 +1,33 @@
+import { breakpoints } from '@assets/themes/globalTheme';
+import { Button } from 'antd';
+import styled from 'styled-components';
+
+export const NavbarWrapper = styled.header`
+  padding: 1rem;
+  display: flex;
+  background-color: var(--primary-color);
+  color: var(--gray-1);
+  z-index: 100;
+  box-shadow: 0px 0.25rem 0.25rem rgba(0, 0, 0, 0.3);
+`;
+
+export const Logo = styled.img`
+  height: 2.5rem;
+  margin: 0 0.5rem;
+  cursor: pointer;
+`;
+
+export const Title = styled.span`
+  font-size: 1.5rem;
+  font-weight: 300;
+  line-height: 1.5;
+  display: none;
+
+  @media (min-width: ${breakpoints.md}) {
+    display: inline;
+  }
+`;
+
+export const SearchButton = styled(Button)`
+  color: var(--gray-1) !important;
+`;

--- a/src/components/ShareButton/ShareModal.tsx
+++ b/src/components/ShareButton/ShareModal.tsx
@@ -19,54 +19,7 @@ import {
   TelegramShareButton,
   TwitterShareButton,
 } from 'react-share';
-import styled from 'styled-components';
-
-const StyledShareButtonWrapper = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-gap: 2rem;
-  font-size: 1.2rem;
-
-  & > button {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 0.8rem !important;
-    border-radius: 0.5rem;
-    transition-duration: 0.3s;
-    transition-property: background-color, opacity;
-
-    &[aria-label] {
-      border: 1px solid var(--gray-5) !important;
-      background-color: var(--gray-1) !important;
-
-      &:hover {
-        background-color: var(--gray-4) !important;
-      }
-
-      & > [data-icon] {
-        font-size: 2rem;
-        margin-right: 0.7rem;
-      }
-    }
-  }
-`;
-
-const StyledCopyButton = styled.button`
-  grid-column: 1 / 3;
-  background-color: var(--primary-color);
-  cursor: pointer;
-  color: var(--gray-1);
-  border: none;
-
-  &:hover {
-    opacity: 0.8;
-  }
-
-  & > [data-icon] {
-    margin-right: 0.5rem;
-  }
-`;
+import { CopyButton, ShareButtonWrapper } from './styles';
 
 export interface ShareModalProps {
   open: boolean;
@@ -88,7 +41,7 @@ const ShareModal: FunctionComponent<ShareModalProps> = ({ open, onCancel, url, c
 
   return (
     <Modal title="分享" visible={open} centered footer={null} onCancel={onCancel}>
-      <StyledShareButtonWrapper>
+      <ShareButtonWrapper>
         <FacebookShareButton url={url}>
           <FontAwesomeIcon icon={faFacebook} style={{ color: '#2e89ff' }} />
           Facebook
@@ -113,11 +66,11 @@ const ShareModal: FunctionComponent<ShareModalProps> = ({ open, onCancel, url, c
           <FontAwesomeIcon icon={faTwitter} style={{ color: '#1d9bf0' }} />
           Twitter
         </TwitterShareButton>
-        <StyledCopyButton onClick={copy}>
+        <CopyButton onClick={copy}>
           <FontAwesomeIcon icon={faLink} />
           複製連結
-        </StyledCopyButton>
-      </StyledShareButtonWrapper>
+        </CopyButton>
+      </ShareButtonWrapper>
     </Modal>
   );
 };

--- a/src/components/ShareButton/styles.ts
+++ b/src/components/ShareButton/styles.ts
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+
+export const ShareButtonWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 2rem;
+  font-size: 1.2rem;
+
+  & > button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0.8rem !important;
+    border-radius: 0.5rem;
+    transition-duration: 0.3s;
+    transition-property: background-color, opacity;
+
+    &[aria-label] {
+      border: 1px solid var(--gray-5) !important;
+      background-color: var(--gray-1) !important;
+
+      &:hover {
+        background-color: var(--gray-4) !important;
+      }
+
+      & > [data-icon] {
+        font-size: 2rem;
+        margin-right: 0.7rem;
+      }
+    }
+  }
+`;
+
+export const CopyButton = styled.button`
+  grid-column: 1 / 3;
+  background-color: var(--primary-color);
+  cursor: pointer;
+  color: var(--gray-1);
+  border: none;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  & > [data-icon] {
+    margin-right: 0.5rem;
+  }
+`;

--- a/src/pages/Landing/BookstoreItem.tsx
+++ b/src/pages/Landing/BookstoreItem.tsx
@@ -4,21 +4,7 @@ import { faCheckCircle, faTimesCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import getBookstoreLogo from '@utils/assets/getBookstoreLogo';
 import { FunctionComponent } from 'react';
-import styled from 'styled-components';
-
-const StyledLogo = styled.img`
-  width: 2.5rem;
-  height: 2.5rem;
-  border: 1px solid var(--gray-4);
-  border-radius: 50%;
-  overflow: hidden;
-`;
-
-const StyledBoostoreLink = styled.a`
-  margin: 0 0.5rem;
-  font-weight: 300;
-  color: var(--gray-7);
-`;
+import { BookstoreLink, BookstoreLogo } from './styles';
 
 const BookstoreItem: FunctionComponent<BookstoreData> = ({
   id,
@@ -28,10 +14,10 @@ const BookstoreItem: FunctionComponent<BookstoreData> = ({
 }) => {
   return (
     <Box display="flex" alignItems="center">
-      <StyledLogo src={getBookstoreLogo(id)} />
-      <StyledBoostoreLink href={website} target="_blank" rel="noreferrer">
+      <BookstoreLogo src={getBookstoreLogo(id)} />
+      <BookstoreLink href={website} target="_blank" rel="noreferrer">
         {displayName}
-      </StyledBoostoreLink>
+      </BookstoreLink>
       {isOnline ? (
         <FontAwesomeIcon icon={faCheckCircle} style={{ color: 'var(--success-color)' }} />
       ) : (

--- a/src/pages/Landing/BookstoreSupport.tsx
+++ b/src/pages/Landing/BookstoreSupport.tsx
@@ -3,73 +3,40 @@ import { faCheckCircle, faTimesCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Popover } from 'antd';
 import { FunctionComponent } from 'react';
-import styled from 'styled-components';
-
 import BookstoreItem from './BookstoreItem';
-
-const StyledBookstoreSupport = styled.p`
-  align-items: center;
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 300;
-  color: var(--gray-7);
-  cursor: default;
-`;
-
-const StyledWhichBookstore = styled.span`
-  margin-left: 0.2rem;
-  color: var(--primary-5);
-  cursor: pointer;
-`;
-
-const StyledBookstores = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  grid-column-gap: 2rem;
-  grid-row-gap: 2rem;
-  padding: 0.3rem 0;
-`;
-
-const StyledOnlineDesc = styled.div`
-  grid-column: span 2;
-  border-top: 1px solid var(--gray-4);
-  padding-top: 1rem;
-  font-weight: 300;
-  color: var(--gray-7);
-  display: flex;
-  align-items: center;
-
-  & *:nth-child(even):not(:last-child) {
-    margin-right: 1rem;
-  }
-`;
+import {
+  BookstoresContainer,
+  BookstoreSupportWrapper,
+  ServiceStatusDesc,
+  WhichBookstores,
+} from './styles';
 
 const BookstoreSupport: FunctionComponent = () => {
   const { bookstores } = useBookstores();
 
   return (
-    <StyledBookstoreSupport>
+    <BookstoreSupportWrapper>
       看看支援
       <Popover
         placement="bottom"
         trigger="click"
         content={
-          <StyledBookstores>
+          <BookstoresContainer>
             {bookstores && bookstores.map((item) => <BookstoreItem key={item.id} {...item} />)}
-            <StyledOnlineDesc>
+            <ServiceStatusDesc>
               <FontAwesomeIcon icon={faCheckCircle} style={{ color: 'var(--success-color)' }} />
               <span>：服務中</span>
               <FontAwesomeIcon icon={faTimesCircle} style={{ color: 'var(--error-color)' }} />
               <span>：暫停服務</span>
-            </StyledOnlineDesc>
-          </StyledBookstores>
+            </ServiceStatusDesc>
+          </BookstoresContainer>
         }
       >
-        <StyledWhichBookstore>
+        <WhichBookstores>
           哪{bookstores ? ` ${bookstores.length} ` : '幾'}間台灣線上電子書店
-        </StyledWhichBookstore>
+        </WhichBookstores>
       </Popover>
-    </StyledBookstoreSupport>
+    </BookstoreSupportWrapper>
   );
 };
 

--- a/src/pages/Landing/TwitterPromotion.tsx
+++ b/src/pages/Landing/TwitterPromotion.tsx
@@ -1,28 +1,13 @@
 import { faTwitter } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { FunctionComponent } from 'react';
-import styled from 'styled-components';
-
-const StyledTwitterPromotion = styled.h3`
-  display: flex;
-  align-items: center;
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 300;
-  color: var(--gray-7);
-  cursor: pointer;
-  transition: color 0.3s;
-
-  &:hover {
-    color: var(--primary-5);
-  }
-`;
+import { TwitterPromotionWrapper } from './styles';
 
 const TwitterPromotion: FunctionComponent = () => (
-  <StyledTwitterPromotion onClick={() => window.open('https://twitter.com/TaiwanEBook', '_blank')}>
+  <TwitterPromotionWrapper onClick={() => window.open('https://twitter.com/TaiwanEBook', '_blank')}>
     <FontAwesomeIcon icon={faTwitter} style={{ fontSize: '2em', marginRight: '0.75rem' }} />
     在推特上追蹤我們
-  </StyledTwitterPromotion>
+  </TwitterPromotionWrapper>
 );
 
 export default TwitterPromotion;

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -8,23 +8,11 @@ import useNavigateToSearch from '@hooks/useNavigateToSearch';
 import { message, Typography } from 'antd';
 import { FunctionComponent, useEffect } from 'react';
 import GHCorner from 'react-gh-corner';
-import styled, { createGlobalStyle } from 'styled-components';
-import { maxWidth, MaxWidthProps } from 'styled-system';
-
 import BookstoreSupport from './BookstoreSupport';
+import { EbookLogo, LandingPageStyle } from './styles';
 import TwitterPromotion from './TwitterPromotion';
 
 const { Title } = Typography;
-
-const StyledLogo = styled.img<MaxWidthProps>`
-  ${maxWidth}
-`;
-
-const GlobalStyle = createGlobalStyle`
-  body {
-    background-color: var(--gray-3) !important;
-  }
-`;
 
 const Landing: FunctionComponent = () => {
   const onSubmit = useNavigateToSearch();
@@ -36,7 +24,7 @@ const Landing: FunctionComponent = () => {
 
   return (
     <>
-      <GlobalStyle />
+      <LandingPageStyle />
       <Box display="flex" padding="1rem" justifyContent="flex-end">
         <GetApp />
       </Box>
@@ -48,7 +36,7 @@ const Landing: FunctionComponent = () => {
         flex="1"
         px="1rem"
       >
-        <StyledLogo src={logo} maxWidth={['40vw', null, '16.4rem']} />
+        <EbookLogo src={logo} maxWidth={['40vw', null, '16.4rem']} />
         <Title level={2} style={{ marginTop: '1rem', marginBottom: '3rem', fontWeight: 400 }}>
           台灣電子書搜尋
         </Title>

--- a/src/pages/Landing/styles.ts
+++ b/src/pages/Landing/styles.ts
@@ -1,0 +1,94 @@
+import styled, { createGlobalStyle } from 'styled-components';
+import { maxWidth, MaxWidthProps } from 'styled-system';
+
+/**
+ * index
+ */
+
+export const LandingPageStyle = createGlobalStyle`
+  body {
+    background-color: var(--gray-3) !important;
+  }
+`;
+
+export const EbookLogo = styled.img<MaxWidthProps>`
+  ${maxWidth}
+`;
+
+/**
+ * TwitterPromotion
+ */
+
+export const TwitterPromotionWrapper = styled.h3`
+  display: flex;
+  align-items: center;
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 300;
+  color: var(--gray-7);
+  cursor: pointer;
+  transition: color 0.3s;
+
+  &:hover {
+    color: var(--primary-5);
+  }
+`;
+
+/**
+ * BookstoreSupport
+ */
+
+export const BookstoreSupportWrapper = styled.p`
+  align-items: center;
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 300;
+  color: var(--gray-7);
+  cursor: default;
+`;
+
+export const BookstoresContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-column-gap: 2rem;
+  grid-row-gap: 2rem;
+  padding: 0.3rem 0;
+`;
+
+export const ServiceStatusDesc = styled.div`
+  grid-column: span 2;
+  border-top: 1px solid var(--gray-4);
+  padding-top: 1rem;
+  font-weight: 300;
+  color: var(--gray-7);
+  display: flex;
+  align-items: center;
+
+  & *:nth-child(even):not(:last-child) {
+    margin-right: 1rem;
+  }
+`;
+
+export const WhichBookstores = styled.span`
+  margin-left: 0.2rem;
+  color: var(--primary-5);
+  cursor: pointer;
+`;
+
+/**
+ * BookstoreItem
+ */
+
+export const BookstoreLogo = styled.img`
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid var(--gray-4);
+  border-radius: 50%;
+  overflow: hidden;
+`;
+
+export const BookstoreLink = styled.a`
+  margin: 0 0.5rem;
+  font-weight: 300;
+  color: var(--gray-7);
+`;

--- a/src/pages/Search/BookItem.tsx
+++ b/src/pages/Search/BookItem.tsx
@@ -2,106 +2,26 @@ import Box from '@components/Box';
 import { BooksOfBookstoreParamType, BookWithBookstore } from '@recoil/searchResults';
 import getBookstoreLogo from '@utils/assets/getBookstoreLogo';
 import { Dispatch, FunctionComponent, useCallback } from 'react';
-import styled from 'styled-components';
 import {
-  compose,
-  fontSize,
-  FontSizeProps,
-  gridTemplateColumns,
-  GridTemplateColumnsProps,
-  margin,
-  MarginProps,
-  maxHeight,
-  MaxHeightProps,
-  maxWidth,
-  MaxWidthProps,
-} from 'styled-system';
+  ItemAbout,
+  ItemImage,
+  ItemLayout,
+  ItemPrice,
+  ItemStoreBadge,
+  ItemStoreLogo,
+  ItemTitle,
+} from './styles';
 
 export interface BookItemProps {
   book: BookWithBookstore;
   setCurrentTab: Dispatch<BooksOfBookstoreParamType>;
 }
 
-const StyledImage = styled.img`
-  object-fit: contain;
-  max-height: 100%;
-  max-width: 100%;
-  border: 1px solid var(--gray-4);
-  border-radius: 0.5rem;
-  overflow: hidden;
-`;
-
-const StyledStoreBadge = styled.span<FontSizeProps>`
-  display: inline-flex;
-  align-items: center;
-  background-color: var(--gray-4);
-  padding-right: 1rem;
-  border-radius: 0.75rem;
-  ${fontSize}
-`;
-
-const StyledLogo = styled.img<MarginProps & MaxHeightProps & MaxWidthProps>`
-  border: 1px solid var(--gray-4);
-  border-radius: 50%;
-  overflow: hidden;
-  ${compose(margin, maxHeight, maxWidth)}
-`;
-
-const StyledTitle = styled.h3<FontSizeProps>`
-  margin: auto 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  ${fontSize}
-`;
-
-const StyledAbout = styled.p<FontSizeProps & MaxHeightProps>`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  line-clamp: 3;
-  -webkit-box-orient: vertical;
-  margin: 0;
-  ${compose(fontSize, maxHeight)}
-`;
-
-const StyledPrice = styled.span<FontSizeProps>`
-  color: var(--primary-6);
-  margin: 0;
-  ${fontSize}
-`;
-
-const StyledBookGrid = styled.div<GridTemplateColumnsProps>`
-  height: 15rem;
-  max-height: 15rem;
-  max-width: 100vw;
-  display: grid;
-  grid-template-rows: 1.5rem 2.55rem 1fr 3rem;
-  grid-template-areas:
-    'thumbnail bookstore'
-    'thumbnail title'
-    'thumbnail about'
-    'thumbnail price';
-  grid-gap: 0.5rem 2rem;
-  line-height: 1.5;
-  margin-bottom: 2rem;
-  ${gridTemplateColumns}
-
-  & ${StyledImage}, ${StyledStoreBadge}, ${StyledTitle}, ${StyledAbout}, ${StyledPrice} {
-    cursor: pointer;
-    transition: opacity 0.3s;
-    &:hover {
-      opacity: 0.8;
-    }
-  }
-`;
-
 const BookItem: FunctionComponent<BookItemProps> = ({ book, setCurrentTab }) => {
   const openBookHref = useCallback(() => window.open(book.link, '_blank'), [book.link]);
 
   return (
-    <StyledBookGrid
+    <ItemLayout
       gridTemplateColumns={[
         '8rem minmax(0, 1fr)',
         '10rem minmax(0, 1fr)',
@@ -116,47 +36,47 @@ const BookItem: FunctionComponent<BookItemProps> = ({ book, setCurrentTab }) => 
         alignItems="center"
         width={['8rem', '10rem', '11rem', '12rem']}
       >
-        <StyledImage src={book.thumbnail} onClick={openBookHref} />
+        <ItemImage src={book.thumbnail} onClick={openBookHref} />
       </Box>
       <Box gridArea="bookstore" display="flex" alignItems="center">
-        <StyledStoreBadge
+        <ItemStoreBadge
           fontSize={['0.8rem', null, null, '1rem']}
           onClick={() => setCurrentTab(book.bookstoreId)}
         >
-          <StyledLogo
+          <ItemStoreLogo
             src={getBookstoreLogo(book.bookstoreId)}
             mr={['0.6rem', null, null, '0.75rem']}
             maxHeight={['1.2rem', null, null, '1.5rem']}
             maxWidth={['1.2rem', null, null, '1.5rem']}
           />
           {book.bookstoreName}
-        </StyledStoreBadge>
+        </ItemStoreBadge>
       </Box>
       <Box gridArea="title" maxWidth="100%">
-        <StyledTitle fontSize={['1.4rem', null, null, '1.7rem']} onClick={openBookHref}>
+        <ItemTitle fontSize={['1.4rem', null, null, '1.7rem']} onClick={openBookHref}>
           {book.title}
-        </StyledTitle>
+        </ItemTitle>
       </Box>
       <Box gridArea="about">
-        <StyledAbout
+        <ItemAbout
           fontSize={['1rem', null, null, '1.2rem']}
           maxHeight={['4.5rem', null, null, '5.4rem']}
           onClick={openBookHref}
         >
           {book.about}
-        </StyledAbout>
+        </ItemAbout>
       </Box>
       <Box gridArea="price">
-        <StyledPrice fontSize={['1rem', null, null, '1.2rem']} onClick={openBookHref}>
+        <ItemPrice fontSize={['1rem', null, null, '1.2rem']} onClick={openBookHref}>
           {new Intl.NumberFormat('en-us', {
             style: 'currency',
             currency: book.priceCurrency || 'TWD',
             minimumFractionDigits: 0,
             maximumFractionDigits: 0,
           }).format(book.price)}
-        </StyledPrice>
+        </ItemPrice>
       </Box>
-    </StyledBookGrid>
+    </ItemLayout>
   );
 };
 

--- a/src/pages/Search/index.tsx
+++ b/src/pages/Search/index.tsx
@@ -12,26 +12,9 @@ import { isEmpty } from 'lodash-es';
 import { FunctionComponent, useEffect, useState } from 'react';
 import { forceCheck } from 'react-lazyload';
 import { useRecoilValue } from 'recoil';
-import styled from 'styled-components';
 import ResultEmpty from './ResultEmpty';
 import ResultList from './ResultList';
-
-const StyledHeaderWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  position: sticky;
-  top: 0;
-  background-color: var(--gray-1);
-  z-index: 1;
-`;
-
-const StyledBorder = styled.div`
-  position: absolute;
-  width: 100%;
-  left: 0;
-  bottom: 0;
-  border-bottom: 1px solid var(--gray-4);
-`;
+import { HeaderWrapper, TabsBorder } from './styles';
 
 const { TabPane } = Tabs;
 
@@ -50,7 +33,7 @@ const Search: FunctionComponent = () => {
 
   return (
     <>
-      <StyledHeaderWrapper>
+      <HeaderWrapper>
         <Tabs
           activeKey={currentTab}
           tabBarGutter={28}
@@ -65,8 +48,8 @@ const Search: FunctionComponent = () => {
             <TabPane tab={bookstore.displayName} key={bookstore.id} />
           ))}
         </Tabs>
-        <StyledBorder />
-      </StyledHeaderWrapper>
+        <TabsBorder />
+      </HeaderWrapper>
       <Box maxWidth={breakpoints.xl} mx="auto">
         {isEmpty(booksOfCurrentTab) ? (
           <ResultEmpty />

--- a/src/pages/Search/styles.ts
+++ b/src/pages/Search/styles.ts
@@ -1,0 +1,114 @@
+import styled from 'styled-components';
+import {
+  compose,
+  fontSize,
+  FontSizeProps,
+  gridTemplateColumns,
+  GridTemplateColumnsProps,
+  margin,
+  MarginProps,
+  maxHeight,
+  MaxHeightProps,
+  maxWidth,
+  MaxWidthProps,
+} from 'styled-system';
+
+/**
+ * index
+ */
+
+export const HeaderWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  position: sticky;
+  top: 0;
+  background-color: var(--gray-1);
+  z-index: 1;
+`;
+
+export const TabsBorder = styled.div`
+  position: absolute;
+  width: 100%;
+  left: 0;
+  bottom: 0;
+  border-bottom: 1px solid var(--gray-4);
+`;
+
+/**
+ * BookItem
+ */
+
+export const ItemImage = styled.img`
+  object-fit: contain;
+  max-height: 100%;
+  max-width: 100%;
+  border: 1px solid var(--gray-4);
+  border-radius: 0.5rem;
+  overflow: hidden;
+`;
+
+export const ItemStoreBadge = styled.span<FontSizeProps>`
+  display: inline-flex;
+  align-items: center;
+  background-color: var(--gray-4);
+  padding-right: 1rem;
+  border-radius: 0.75rem;
+  ${fontSize}
+`;
+
+export const ItemStoreLogo = styled.img<MarginProps & MaxHeightProps & MaxWidthProps>`
+  border: 1px solid var(--gray-4);
+  border-radius: 50%;
+  overflow: hidden;
+  ${compose(margin, maxHeight, maxWidth)}
+`;
+
+export const ItemTitle = styled.h3<FontSizeProps>`
+  margin: auto 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  ${fontSize}
+`;
+
+export const ItemAbout = styled.p<FontSizeProps & MaxHeightProps>`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  margin: 0;
+  ${compose(fontSize, maxHeight)}
+`;
+
+export const ItemPrice = styled.span<FontSizeProps>`
+  color: var(--primary-6);
+  margin: 0;
+  ${fontSize}
+`;
+
+export const ItemLayout = styled.div<GridTemplateColumnsProps>`
+  height: 15rem;
+  max-height: 15rem;
+  max-width: 100vw;
+  display: grid;
+  grid-template-rows: 1.5rem 2.55rem 1fr 3rem;
+  grid-template-areas:
+    'thumbnail bookstore'
+    'thumbnail title'
+    'thumbnail about'
+    'thumbnail price';
+  grid-gap: 0.5rem 2rem;
+  line-height: 1.5;
+  margin-bottom: 2rem;
+  ${gridTemplateColumns}
+
+  & ${ItemImage}, ${ItemStoreBadge}, ${ItemTitle}, ${ItemAbout}, ${ItemPrice} {
+    cursor: pointer;
+    transition: opacity 0.3s;
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+`;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
  Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

（ＰＲ看起來很大，其實都是搬一下 code，ok 的）
參考一些管理 style 結構的 Best practice，styled-components 在使用上，有時候會佔據了 `.tsx` 檔案許多篇幅，
為了使 `.tsx` 更清晰的在表達邏輯，因此將樣式的部分搬到 `styles.ts` 中。

> 不過像是沒有什麼邏輯的元件，像是 `BooksLoading.tsx`，
或是像 `FilterCheckboxes` 中的 style 只有一個，將 style 拆出去還可能造成麻煩的，就不會在這次優化的範圍。

未來要找樣式時，也會方便一些，如下圖：
<img width="743" alt="圖片" src="https://user-images.githubusercontent.com/13966758/152764492-d79e9d46-be11-4340-90f8-180a01c4f7d5.png">

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

這次沒有任何新功能或修復，僅做程式碼結構的調整，
因此系統沒壞掉就好 👌 
